### PR TITLE
feat: add default issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG.yaml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: File a bug report.
+title: ""
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this Bug.
+  - type: textarea
+    id: describe
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: I got an HTTP Error Code that I think is wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To Reproduce
+      description: How can the maintainers reproduce this behavior?
+      placeholder: 1. Create a Resource. 2. Get the Resource. 3. Observe boom.
+    validations:
+      required: true
+  - type: textarea
+    id: material
+    attributes:
+      label: Logs/Screenshots
+      description: Please leave logs/screenshots if you have them
+  - type: textarea
+    id: impl
+    attributes:
+      label: Possible implementation
+      description: You already know the root cause of the erroneous state and how to fix it? Feel free to share your thoughts.
+

--- a/.github/ISSUE_TEMPLATE/FEATURE.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE.yaml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Request a new feature
+title: ""
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your ideas how to improve this project!
+  - type: textarea
+    id: what
+    attributes:
+      label: WHAT
+      description: describe the desired feature and how it should behave. This should include a _Definition of Done_.
+      placeholder: I got an HTTP Error Code that I think is wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: WHY
+      description: outline the motivation why it's desired and the impact if the feature is _not_ implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: how
+    attributes:
+      label: HOW
+      description: Outline a solution proposal
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Please provide additional context to this request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## WHAT
+
+_Briefly describe what your PR changes, which features it adds/modifies._
+
+## WHY
+
+_Briefly state why the change was necessary._
+
+## FURTHER NOTES
+
+_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
+
+Closes # <-- _insert Issue number if one exists_


### PR DESCRIPTION
Not all repos currently have templates for issues and PRs. This can be overridden by maintaining such templates in the individual repos' `.github` folder