### PR TITLE
docs: announce org-wide repository archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # .github
+
+> [!IMPORTANT]
+> **The repositories in this organization are archived.** They will receive no further development or maintenance. Interested parties are invited to fork the repositories and continue the work independently.
+
 We are creating an open and collaborative digital ecosystem for factory outfitters and operators, built on the foundations of Catena‑X and the principles of Plattform Industrie 4.0.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,8 @@
 # Factory-X Contributions
 
+> [!IMPORTANT]
+> **The repositories in this organization are archived.** They will receive no further development or maintenance. Interested parties are invited to fork the repositories and continue the work independently.
+
 We are creating an open and collaborative digital ecosystem for factory outfitters and operators, built on the foundations of Catena‑X and the principles of Plattform Industrie 4.0. In this repository we are releasing services as well as architecture decisions to allow third parties to participate in the ecosystem. Further information about Factory-X can be found here https://factory-x.org/.
 
 


### PR DESCRIPTION
Adds an archival notice to both `README.md` and `profile/README.md` announcing that the repositories in this organization will receive no further development and inviting interested parties to fork.